### PR TITLE
feat: wire fact-checking into pipeline (#83)

### DIFF
--- a/src/pipeline/actions.ts
+++ b/src/pipeline/actions.ts
@@ -16,6 +16,9 @@ import { extractVerdict } from './engine.js';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { ensureRosterContext, validatePlayerMentions } from './roster-context.js';
+import { extractClaims, totalClaimCount } from './claim-extractor.js';
+import { ensureFactCheckContext } from './fact-check-context.js';
+import { validateStatClaims, validateDraftClaims, buildValidationReport } from './validators.js';
 import { estimateCost } from '../llm/pricing.js';
 
 // ── Types ───────────────────────────────────────────────────────────────────
@@ -561,13 +564,34 @@ async function writeDraft(articleId: string, ctx: ActionContext): Promise<Action
     // Run lightweight fact-check on panel discussion output (if available)
     const discussionArtifact = ctx.repo.artifacts.get(articleId, 'discussion-summary.md');
     if (discussionArtifact) {
-      const factcheckContent = rosterCtx
-        ? discussionArtifact + '\n\n---\n\n' + rosterCtx
-        : discussionArtifact;
+      // Extract verifiable claims and build nflverse fact-check context
+      const panelTexts = [discussionArtifact];
+      // Also gather individual panel outputs for broader claim extraction
+      const allArtifacts = ctx.repo.artifacts.list(articleId);
+      for (const a of allArtifacts) {
+        if (a.name.startsWith('panel-') && a.name !== 'panel-factcheck.md' && a.name !== 'panel-composition.md') {
+          const content = ctx.repo.artifacts.get(articleId, a.name);
+          if (content) panelTexts.push(content);
+        }
+      }
+      const combinedPanelText = panelTexts.join('\n\n');
+      const claims = extractClaims(combinedPanelText);
+
+      // Build enriched fact-check context from nflverse if claims found
+      let factCheckCtxArtifact: string | null = null;
+      if (totalClaimCount(claims) > 0) {
+        const fctx = ensureFactCheckContext(ctx.repo, articleId, claims);
+        if (fctx) factCheckCtxArtifact = fctx.raw;
+      }
+
+      const factcheckParts = [discussionArtifact];
+      if (rosterCtx) factcheckParts.push(rosterCtx);
+      if (factCheckCtxArtifact) factcheckParts.push(factCheckCtxArtifact);
+      const factcheckContent = factcheckParts.join('\n\n---\n\n');
 
       const factCheckResult = await ctx.runner.run({
         agentName: 'lead',
-        task: 'Run a lightweight preflight fact-check on the panel discussion output. Focus on high-risk claims: contract figures, statistics, injury timelines, draft facts, and direct quotes. Flag contradictions between panelists. Cross-reference player-team assignments against the roster data provided. If a player is mentioned but not found in the roster, flag as ⚠️ CAUTION (the data updates daily — very recent transactions may not be reflected yet). Only flag as 🔴 ERROR if a player is clearly on a different team in the roster data.',
+        task: 'Run a lightweight preflight fact-check on the panel discussion output. Focus on high-risk claims: contract figures, statistics, injury timelines, draft facts, and direct quotes. Flag contradictions between panelists. Cross-reference player-team assignments against the roster data provided. Use the nflverse verification data (if included below) to compare claimed statistics against actual data — flag any discrepancies. If a player is mentioned but not found in the roster, flag as ⚠️ CAUTION (the data updates daily — very recent transactions may not be reflected yet). Only flag as 🔴 ERROR if a player is clearly on a different team in the roster data or if statistics are provably wrong per nflverse data.',
         skills: ['fact-checking'],
         articleContext: {
           slug: articleId,
@@ -659,6 +683,12 @@ async function runEditor(articleId: string, ctx: ActionContext): Promise<ActionR
       if (rosterCtx) {
         content = content + '\n\n---\n\n' + rosterCtx;
       }
+    }
+
+    // Inject fact-check context if available (built during writeDraft stage)
+    const factCheckArtifact = ctx.repo.artifacts.get(articleId, 'fact-check-context.md');
+    if (factCheckArtifact) {
+      content = content + '\n\n---\n\n' + factCheckArtifact;
     }
 
     const result = await ctx.runner.run({
@@ -755,6 +785,15 @@ async function runPublisherPass(articleId: string, ctx: ActionContext): Promise<
           }).join('\n');
           const validationArtifact = `## Pre-Publish Roster Validation\n\n${warnings}\n\n*${mentions.filter(m => m.status === 'confirmed').length} player names confirmed on roster.*`;
           ctx.repo.artifacts.put(articleId, 'roster-validation.md', validationArtifact);
+        }
+
+        // Run deterministic stat and draft claim validation
+        const claims = extractClaims(draftContent);
+        if (totalClaimCount(claims) > 0) {
+          const statResults = validateStatClaims(claims);
+          const draftResults = validateDraftClaims(claims);
+          const report = buildValidationReport(statResults, draftResults);
+          ctx.repo.artifacts.put(articleId, 'fact-validation.md', report);
         }
       }
     }

--- a/src/pipeline/claim-extractor.ts
+++ b/src/pipeline/claim-extractor.ts
@@ -1,0 +1,307 @@
+/**
+ * claim-extractor.ts — Lightweight extraction of verifiable claims from
+ * panel markdown outputs.
+ *
+ * Extracts four categories of claims:
+ *   1. Statistical claims (EPA, yards, completion %, passer rating, etc.)
+ *   2. Contract/cap claims (dollar amounts, contract years, cap hit)
+ *   3. Draft claims (pick numbers, round references, draft year)
+ *   4. Performance claims (rankings, comparisons, league-leading stats)
+ *
+ * Called before the LLM fact-check so nflverse can be queried for
+ * ground-truth data to enrich the fact-check context.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface StatClaim {
+  player: string;
+  metric: string;
+  value: string;
+  raw: string;
+}
+
+export interface ContractClaim {
+  player: string;
+  detail: string;
+  raw: string;
+}
+
+export interface DraftClaim {
+  player: string;
+  round?: number;
+  pick?: number;
+  year?: number;
+  raw: string;
+}
+
+export interface PerformanceClaim {
+  player: string;
+  claim: string;
+  raw: string;
+}
+
+export interface ExtractedClaims {
+  statClaims: StatClaim[];
+  contractClaims: ContractClaim[];
+  draftClaims: DraftClaim[];
+  performanceClaims: PerformanceClaim[];
+}
+
+// ---------------------------------------------------------------------------
+// Name extraction helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Strip markdown formatting so regex sees clean prose text.
+ * Removes bold markers, heading lines, and horizontal rules.
+ */
+function stripMarkdown(text: string): string {
+  return text
+    .replace(/^#{1,6}\s+.*$/gm, '')  // Remove heading lines
+    .replace(/^---+$/gm, '')          // Remove horizontal rules
+    .replace(/\*\*/g, '');            // Remove bold markers
+}
+
+/**
+ * Non-sentence-ending character pattern for use in regex strings.
+ * Matches any character that isn't a sentence-ending period.
+ * Allows periods in numbers (e.g. "0.12", "7.5") and abbreviations.
+ */
+const SENT = `(?:[^.]|\\.[\\d])`;
+
+
+/**
+ * Match a player-like name: "First Last", "First Last Jr.", "First Last III"
+ * Must start with uppercase letter followed by lowercase, then at least one more
+ * word starting with uppercase (or suffix like Jr., III, IV).
+ * Does NOT use 'i' flag — case-sensitive to avoid matching phrases like "He had".
+ */
+const NAME_PAT_CS = `([A-Z][a-z]+(?:\\s+(?:[A-Z][a-zA-Z'-]+|[IVX]+|[JS]r\\.?))+)`;
+
+// ---------------------------------------------------------------------------
+// Statistical claims
+// ---------------------------------------------------------------------------
+
+interface StatPattern {
+  regex: RegExp;
+  metric: string;
+}
+
+const STAT_PATTERNS: StatPattern[] = [
+  // EPA
+  { regex: new RegExp(`${NAME_PAT_CS}${SENT}*?([-+]?\\d+\\.\\d+)\\s*EPA`, 'g'), metric: 'EPA' },
+  { regex: new RegExp(`${NAME_PAT_CS}${SENT}*?EPA\\s*(?:of|:)?\\s*([-+]?\\d+\\.\\d+)`, 'g'), metric: 'EPA' },
+  // Passing yards
+  { regex: new RegExp(`${NAME_PAT_CS}${SENT}*?(\\d[\\d,]+)\\s*(?:passing|pass)\\s*yards`, 'g'), metric: 'passing_yards' },
+  // Rushing yards
+  { regex: new RegExp(`${NAME_PAT_CS}${SENT}*?(\\d[\\d,]+)\\s*(?:rushing|rush)\\s*yards`, 'g'), metric: 'rushing_yards' },
+  // Receiving yards
+  { regex: new RegExp(`${NAME_PAT_CS}${SENT}*?(\\d[\\d,]+)\\s*(?:receiving|rec\\.?)\\s*yards`, 'g'), metric: 'receiving_yards' },
+  // Completion percentage
+  { regex: new RegExp(`${NAME_PAT_CS}${SENT}*?(\\d+\\.?\\d*)%?\\s*completion`, 'g'), metric: 'completion_pct' },
+  { regex: new RegExp(`${NAME_PAT_CS}${SENT}*?completion${SENT}*?(\\d+\\.?\\d*)%`, 'g'), metric: 'completion_pct' },
+  // Passer rating
+  { regex: new RegExp(`${NAME_PAT_CS}${SENT}*?(\\d+\\.?\\d*)\\s*passer\\s*rating`, 'g'), metric: 'passer_rating' },
+  // Touchdowns
+  { regex: new RegExp(`${NAME_PAT_CS}${SENT}*?(\\d+)\\s*(?:touchdowns?|TDs?)`, 'g'), metric: 'touchdowns' },
+  // Targets / target share
+  { regex: new RegExp(`${NAME_PAT_CS}${SENT}*?(\\d+\\.?\\d*)%?\\s*target\\s*share`, 'g'), metric: 'target_share' },
+  // Sacks
+  { regex: new RegExp(`${NAME_PAT_CS}${SENT}*?(\\d+\\.?\\d*)\\s*sacks?`, 'g'), metric: 'sacks' },
+  // Interceptions
+  { regex: new RegExp(`${NAME_PAT_CS}${SENT}*?(\\d+)\\s*(?:interceptions?|INTs?)`, 'g'), metric: 'interceptions' },
+  // Success rate
+  { regex: new RegExp(`${NAME_PAT_CS}${SENT}*?(\\d+\\.?\\d*)%?\\s*success\\s*rate`, 'g'), metric: 'success_rate' },
+  // CPOE
+  { regex: new RegExp(`${NAME_PAT_CS}${SENT}*?([-+]?\\d+\\.\\d+)\\s*CPOE`, 'g'), metric: 'cpoe' },
+  // Tackles
+  { regex: new RegExp(`${NAME_PAT_CS}${SENT}*?(\\d+)\\s*(?:total\\s+)?tackles`, 'g'), metric: 'tackles' },
+];
+
+function extractStatClaims(text: string): StatClaim[] {
+  const clean = stripMarkdown(text);
+  const claims: StatClaim[] = [];
+  const seen = new Set<string>();
+
+  for (const { regex, metric } of STAT_PATTERNS) {
+    regex.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = regex.exec(clean)) !== null) {
+      const player = m[1].trim();
+      const value = m[2].trim();
+      const key = `${player}|${metric}|${value}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        claims.push({ player, metric, value, raw: m[0].trim() });
+      }
+    }
+  }
+
+  return claims;
+}
+
+// ---------------------------------------------------------------------------
+// Contract / salary cap claims
+// ---------------------------------------------------------------------------
+
+const CONTRACT_PATTERNS: RegExp[] = [
+  // "$X million" or "$Xm" near a player name
+  new RegExp(`${NAME_PAT_CS}${SENT}*?\\$(\\d+(?:\\.\\d+)?\\s*(?:million|mil|M))`, 'g'),
+  new RegExp(`\\$(\\d+(?:\\.\\d+)?\\s*(?:million|mil|M))${SENT}*?${NAME_PAT_CS}`, 'g'),
+  // "X-year" contract
+  new RegExp(`${NAME_PAT_CS}${SENT}*?(\\d+)[- ]year${SENT}*?(?:deal|contract|extension)`, 'g'),
+  // Cap hit / dead money
+  new RegExp(`${NAME_PAT_CS}${SENT}*?(\\$\\d+(?:\\.\\d+)?\\s*(?:million|mil|M)?)${SENT}*?(?:cap\\s*hit|dead\\s*money)`, 'g'),
+];
+
+function extractContractClaims(text: string): ContractClaim[] {
+  const clean = stripMarkdown(text);
+  const claims: ContractClaim[] = [];
+  const seen = new Set<string>();
+
+  for (const regex of CONTRACT_PATTERNS) {
+    regex.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = regex.exec(clean)) !== null) {
+      // Groups depend on pattern — find the name and the detail
+      const groups = m.slice(1).filter(Boolean);
+      const player = groups.find(g => /^[A-Z][a-z]/.test(g))?.trim() ?? '';
+      const detail = groups.find(g => g !== player)?.trim() ?? '';
+      if (!player) continue;
+      const key = `${player}|${detail}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        claims.push({ player, detail, raw: m[0].trim() });
+      }
+    }
+  }
+
+  return claims;
+}
+
+// ---------------------------------------------------------------------------
+// Draft claims
+// ---------------------------------------------------------------------------
+
+const DRAFT_PATTERNS: { regex: RegExp; groups: ('player' | 'round' | 'pick' | 'year')[] }[] = [
+  // "Player was drafted in round X, pick Y"
+  { regex: new RegExp(`${NAME_PAT_CS}${SENT}*?(?:drafted|selected|picked)${SENT}*?round\\s*(\\d)(?:${SENT}*?pick\\s*(\\d+))?`, 'g'), groups: ['player', 'round', 'pick'] },
+  // "Player was the Nth overall pick"
+  { regex: new RegExp(`${NAME_PAT_CS}${SENT}*?(?:No\\.?\\s*|#)(\\d+)\\s*overall\\s*pick`, 'g'), groups: ['player', 'pick'] },
+  // "Player, a Xth-round pick"
+  { regex: new RegExp(`${NAME_PAT_CS}${SENT}*?(?:a\\s+)?(\\d)(?:st|nd|rd|th)[- ]round\\s*pick`, 'g'), groups: ['player', 'round'] },
+  // "20XX draft" + player name
+  { regex: new RegExp(`(20\\d{2})\\s*(?:NFL\\s*)?[Dd]raft${SENT}*?${NAME_PAT_CS}`, 'g'), groups: ['year', 'player'] },
+  { regex: new RegExp(`${NAME_PAT_CS}${SENT}*?(20\\d{2})\\s*(?:NFL\\s*)?[Dd]raft`, 'g'), groups: ['player', 'year'] },
+];
+
+function extractDraftClaims(text: string): DraftClaim[] {
+  const clean = stripMarkdown(text);
+  const claims: DraftClaim[] = [];
+  const seen = new Set<string>();
+
+  for (const { regex, groups } of DRAFT_PATTERNS) {
+    regex.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = regex.exec(clean)) !== null) {
+      const claim: DraftClaim = { player: '', raw: m[0].trim() };
+      for (let i = 0; i < groups.length; i++) {
+        const val = m[i + 1]?.trim();
+        if (!val) continue;
+        switch (groups[i]) {
+          case 'player': claim.player = val; break;
+          case 'round': claim.round = parseInt(val, 10); break;
+          case 'pick': claim.pick = parseInt(val, 10); break;
+          case 'year': claim.year = parseInt(val, 10); break;
+        }
+      }
+      if (!claim.player) continue;
+      const key = `${claim.player}|${claim.round ?? ''}|${claim.pick ?? ''}|${claim.year ?? ''}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        claims.push(claim);
+      }
+    }
+  }
+
+  return claims;
+}
+
+// ---------------------------------------------------------------------------
+// Performance / ranking claims
+// ---------------------------------------------------------------------------
+
+const PERF_PATTERNS: RegExp[] = [
+  // "top X" rankings
+  new RegExp(`${NAME_PAT_CS}${SENT}*?top[- ]?(\\d+)`, 'g'),
+  // "ranked Nth" / "#N"
+  new RegExp(`${NAME_PAT_CS}${SENT}*?(?:ranked?|#)\\s*(\\d+)(?:st|nd|rd|th)?\\s*(?:in|among|at)`, 'g'),
+  // "led the league" / "league-leading"
+  new RegExp(`${NAME_PAT_CS}${SENT}*?(?:led the (?:league|NFL)|league[- ]leading)`, 'g'),
+  // "best in the NFL" / "worst in the NFL"
+  new RegExp(`${NAME_PAT_CS}${SENT}*?(?:best|worst|highest|lowest|most|fewest)\\s+in\\s+the\\s+(?:NFL|league)`, 'g'),
+];
+
+function extractPerformanceClaims(text: string): PerformanceClaim[] {
+  const clean = stripMarkdown(text);
+  const claims: PerformanceClaim[] = [];
+  const seen = new Set<string>();
+
+  for (const regex of PERF_PATTERNS) {
+    regex.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = regex.exec(clean)) !== null) {
+      const player = m[1].trim();
+      const raw = m[0].trim();
+      if (!seen.has(raw)) {
+        seen.add(raw);
+        claims.push({ player, claim: raw, raw });
+      }
+    }
+  }
+
+  return claims;
+}
+
+// ---------------------------------------------------------------------------
+// Main extractor
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract all verifiable claims from panel markdown text.
+ * Returns structured claims categorised for nflverse query routing.
+ */
+export function extractClaims(text: string): ExtractedClaims {
+  return {
+    statClaims: extractStatClaims(text),
+    contractClaims: extractContractClaims(text),
+    draftClaims: extractDraftClaims(text),
+    performanceClaims: extractPerformanceClaims(text),
+  };
+}
+
+/**
+ * Extract unique player names from all claim types.
+ * Useful for batching nflverse queries.
+ */
+export function extractClaimedPlayers(claims: ExtractedClaims): string[] {
+  const players = new Set<string>();
+  for (const c of claims.statClaims) players.add(c.player);
+  for (const c of claims.contractClaims) players.add(c.player);
+  for (const c of claims.draftClaims) players.add(c.player);
+  for (const c of claims.performanceClaims) players.add(c.player);
+  return [...players];
+}
+
+/** Total claim count across all categories. */
+export function totalClaimCount(claims: ExtractedClaims): number {
+  return (
+    claims.statClaims.length +
+    claims.contractClaims.length +
+    claims.draftClaims.length +
+    claims.performanceClaims.length
+  );
+}

--- a/src/pipeline/context-config.ts
+++ b/src/pipeline/context-config.ts
@@ -24,8 +24,8 @@ export const CONTEXT_CONFIG: Record<string, StageContextEntry> = {
   generatePrompt:   { primary: 'idea.md',               include: [] },
   composePanel:     { primary: 'discussion-prompt.md',  include: ['idea.md'] },
   runDiscussion:    { primary: 'discussion-prompt.md',  include: [] },  // panel-composition injected separately
-  writeDraft:       { primary: 'discussion-summary.md', include: ['idea.md', 'editor-review.md', 'panel-factcheck.md', 'roster-context.md'] },
-  runEditor:        { primary: 'draft.md',              include: ['idea.md', 'discussion-summary.md', 'roster-context.md'] },
+  writeDraft:       { primary: 'discussion-summary.md', include: ['idea.md', 'editor-review.md', 'panel-factcheck.md', 'roster-context.md', 'fact-check-context.md'] },
+  runEditor:        { primary: 'draft.md',              include: ['idea.md', 'discussion-summary.md', 'roster-context.md', 'fact-check-context.md'] },
   runPublisherPass: { primary: 'draft.md',              include: ['editor-review.md', 'roster-context.md'] },
 };
 

--- a/src/pipeline/fact-check-context.ts
+++ b/src/pipeline/fact-check-context.ts
@@ -1,0 +1,281 @@
+/**
+ * fact-check-context.ts — Build enriched fact-check context by querying
+ * nflverse data against claims extracted from panel markdown.
+ *
+ * Follows the same architecture as roster-context.ts:
+ *   - Uses Python scripts in content/data/ via execFileSync
+ *   - Caches results through the global QueryCache
+ *   - Builds a markdown artifact for downstream LLM consumption
+ *   - Graceful degradation when data is unavailable
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  getGlobalCache, DEFAULT_TTL,
+  pythonQueryCacheKey, playerStatsCacheKey, draftHistoryCacheKey,
+} from '../cache/index.js';
+import type { ExtractedClaims, StatClaim, DraftClaim, PerformanceClaim } from './claim-extractor.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface FactCheckLookup {
+  claim: string;
+  nflverseData: string | null;
+  source: string;
+}
+
+export interface FactCheckContext {
+  statLookups: FactCheckLookup[];
+  draftLookups: FactCheckLookup[];
+  performanceLookups: FactCheckLookup[];
+  raw: string;
+}
+
+// ---------------------------------------------------------------------------
+// Script execution (mirrors roster-context.ts)
+// ---------------------------------------------------------------------------
+
+function findScriptDir(): string {
+  const candidates = [
+    join(process.cwd(), 'content', 'data'),
+  ];
+  for (const dir of candidates) {
+    if (existsSync(join(dir, 'query_player_epa.py'))) return dir;
+  }
+  return join(process.cwd(), 'content', 'data');
+}
+
+function runPythonQuery(scriptName: string, args: string[]): string | null {
+  const scriptDir = findScriptDir();
+  const scriptPath = join(scriptDir, scriptName);
+
+  if (!existsSync(scriptPath)) {
+    return null;
+  }
+
+  try {
+    const result = execFileSync('python', [scriptPath, ...args, '--format', 'json'], {
+      encoding: 'utf-8',
+      timeout: 30_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd: scriptDir,
+    });
+    return result.trim();
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Season helper (mirrors roster-context.ts)
+// ---------------------------------------------------------------------------
+
+function currentSeason(): number {
+  const now = new Date();
+  return now.getMonth() < 8 ? now.getFullYear() - 1 : now.getFullYear();
+}
+
+// ---------------------------------------------------------------------------
+// Individual claim lookups
+// ---------------------------------------------------------------------------
+
+/** Look up player stats from nflverse. */
+function lookupPlayerStats(player: string, season: number): string | null {
+  const cache = getGlobalCache();
+  const key = playerStatsCacheKey(player, season);
+  return cache.getOrFetch<string>(key, () => {
+    return runPythonQuery('query_player_epa.py', [
+      '--player', player,
+      '--season', String(season),
+    ]);
+  }, DEFAULT_TTL.playerStats);
+}
+
+/** Look up draft history for a player. */
+function lookupDraftHistory(player: string): string | null {
+  const cache = getGlobalCache();
+  const key = draftHistoryCacheKey([player.toLowerCase()]);
+  return cache.getOrFetch<string>(key, () => {
+    return runPythonQuery('query_draft_value.py', [
+      '--player', player,
+    ]);
+  }, DEFAULT_TTL.draftHistory);
+}
+
+// ---------------------------------------------------------------------------
+// Build lookups for each claim type
+// ---------------------------------------------------------------------------
+
+function buildStatLookups(claims: StatClaim[], season: number): FactCheckLookup[] {
+  const lookups: FactCheckLookup[] = [];
+  const queriedPlayers = new Set<string>();
+
+  for (const claim of claims) {
+    if (queriedPlayers.has(claim.player)) continue;
+    queriedPlayers.add(claim.player);
+
+    const data = lookupPlayerStats(claim.player, season);
+    lookups.push({
+      claim: `${claim.player}: ${claim.metric} = ${claim.value}`,
+      nflverseData: data,
+      source: 'query_player_epa.py',
+    });
+  }
+
+  return lookups;
+}
+
+function buildDraftLookups(claims: DraftClaim[]): FactCheckLookup[] {
+  const lookups: FactCheckLookup[] = [];
+  const queriedPlayers = new Set<string>();
+
+  for (const claim of claims) {
+    if (queriedPlayers.has(claim.player)) continue;
+    queriedPlayers.add(claim.player);
+
+    const data = lookupDraftHistory(claim.player);
+    const claimParts = [`${claim.player}`];
+    if (claim.round) claimParts.push(`round ${claim.round}`);
+    if (claim.pick) claimParts.push(`pick ${claim.pick}`);
+    if (claim.year) claimParts.push(`${claim.year} draft`);
+
+    lookups.push({
+      claim: claimParts.join(', '),
+      nflverseData: data,
+      source: 'query_draft_value.py',
+    });
+  }
+
+  return lookups;
+}
+
+function buildPerformanceLookups(claims: PerformanceClaim[], season: number): FactCheckLookup[] {
+  const lookups: FactCheckLookup[] = [];
+  const queriedPlayers = new Set<string>();
+
+  for (const claim of claims) {
+    if (queriedPlayers.has(claim.player)) continue;
+    queriedPlayers.add(claim.player);
+
+    const data = lookupPlayerStats(claim.player, season);
+    lookups.push({
+      claim: claim.claim,
+      nflverseData: data,
+      source: 'query_player_epa.py',
+    });
+  }
+
+  return lookups;
+}
+
+// ---------------------------------------------------------------------------
+// Markdown builder
+// ---------------------------------------------------------------------------
+
+function formatLookupSection(title: string, lookups: FactCheckLookup[]): string {
+  if (lookups.length === 0) return '';
+
+  const lines: string[] = [`### ${title}`, ''];
+
+  for (const lookup of lookups) {
+    lines.push(`**Claim:** ${lookup.claim}`);
+    if (lookup.nflverseData) {
+      // Truncate very long JSON to keep context manageable
+      const data = lookup.nflverseData.length > 2000
+        ? lookup.nflverseData.slice(0, 2000) + '\n... (truncated)'
+        : lookup.nflverseData;
+      lines.push(`**nflverse data** (${lookup.source}):`);
+      lines.push('```json');
+      lines.push(data);
+      lines.push('```');
+    } else {
+      lines.push(`*No data found in nflverse (${lookup.source})*`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a fact-check context artifact from extracted claims.
+ * Queries nflverse for each claim and produces a markdown document
+ * with the actual data alongside each claim for LLM comparison.
+ *
+ * Returns null if no claims could be verified (graceful degradation).
+ */
+export function buildFactCheckContext(claims: ExtractedClaims): FactCheckContext | null {
+  const season = currentSeason();
+
+  const statLookups = buildStatLookups(claims.statClaims, season);
+  const draftLookups = buildDraftLookups(claims.draftClaims);
+  const performanceLookups = buildPerformanceLookups(claims.performanceClaims, season);
+
+  const totalLookups = statLookups.length + draftLookups.length + performanceLookups.length;
+  if (totalLookups === 0) {
+    return null;
+  }
+
+  const hasAnyData = [...statLookups, ...draftLookups, ...performanceLookups]
+    .some(l => l.nflverseData != null);
+
+  const parts: string[] = [];
+  parts.push('## Fact-Check Context — nflverse Verification Data');
+  parts.push('');
+  parts.push('> This data was queried from nflverse to verify claims in the panel discussion.');
+  parts.push('> Compare each claim against the actual data below. Flag discrepancies.');
+  parts.push('');
+
+  const statSection = formatLookupSection('Statistical Claims', statLookups);
+  const draftSection = formatLookupSection('Draft Claims', draftLookups);
+  const perfSection = formatLookupSection('Performance/Ranking Claims', performanceLookups);
+
+  if (statSection) parts.push(statSection);
+  if (draftSection) parts.push(draftSection);
+  if (perfSection) parts.push(perfSection);
+
+  if (!hasAnyData) {
+    parts.push('*No nflverse data could be retrieved for any claims. Fact-check will rely on LLM knowledge only.*');
+  }
+
+  parts.push('');
+  parts.push(`*${totalLookups} claims checked against nflverse (${season} season data).*`);
+
+  const raw = parts.join('\n');
+
+  return { statLookups, draftLookups, performanceLookups, raw };
+}
+
+/**
+ * Build fact-check context and store as an artifact.
+ * Returns the context object, or null if no claims found / data unavailable.
+ */
+export function ensureFactCheckContext(
+  repo: { artifacts: { get(id: string, name: string): string | null; put(id: string, name: string, content: string): void } },
+  articleId: string,
+  claims: ExtractedClaims,
+  forceRefresh = false,
+): FactCheckContext | null {
+  const ARTIFACT_NAME = 'fact-check-context.md';
+
+  if (!forceRefresh) {
+    const cached = repo.artifacts.get(articleId, ARTIFACT_NAME);
+    if (cached) {
+      return { statLookups: [], draftLookups: [], performanceLookups: [], raw: cached };
+    }
+  }
+
+  const context = buildFactCheckContext(claims);
+  if (context) {
+    repo.artifacts.put(articleId, ARTIFACT_NAME, context.raw);
+  }
+  return context;
+}

--- a/src/pipeline/validators.ts
+++ b/src/pipeline/validators.ts
@@ -1,0 +1,325 @@
+/**
+ * validators.ts — Deterministic post-draft validation against nflverse data.
+ *
+ * Extends the validatePlayerMentions() pattern from roster-context.ts with
+ * additional validators that cross-reference statistical and draft claims
+ * in article text against actual nflverse data.
+ *
+ * Each validator returns an array of ValidationResult objects that can be
+ * surfaced as pre-publish warnings alongside the existing roster validation.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  getGlobalCache, DEFAULT_TTL,
+  playerStatsCacheKey, draftHistoryCacheKey,
+} from '../cache/index.js';
+import type { ExtractedClaims } from './claim-extractor.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ValidationResult {
+  claim: string;
+  verified: boolean;
+  actual: string;
+  source: string;
+}
+
+// ---------------------------------------------------------------------------
+// Script execution (mirrors roster-context.ts)
+// ---------------------------------------------------------------------------
+
+function findScriptDir(): string {
+  const candidates = [
+    join(process.cwd(), 'content', 'data'),
+  ];
+  for (const dir of candidates) {
+    if (existsSync(join(dir, 'query_player_epa.py'))) return dir;
+  }
+  return join(process.cwd(), 'content', 'data');
+}
+
+function runPythonQuery(scriptName: string, args: string[]): string | null {
+  const scriptDir = findScriptDir();
+  const scriptPath = join(scriptDir, scriptName);
+
+  if (!existsSync(scriptPath)) {
+    return null;
+  }
+
+  try {
+    const result = execFileSync('python', [scriptPath, ...args, '--format', 'json'], {
+      encoding: 'utf-8',
+      timeout: 30_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd: scriptDir,
+    });
+    return result.trim();
+  } catch {
+    return null;
+  }
+}
+
+function currentSeason(): number {
+  const now = new Date();
+  return now.getMonth() < 8 ? now.getFullYear() - 1 : now.getFullYear();
+}
+
+// ---------------------------------------------------------------------------
+// Stat validation
+// ---------------------------------------------------------------------------
+
+interface PlayerStatData {
+  player_display_name?: string;
+  passing_yards?: number;
+  rushing_yards?: number;
+  receiving_yards?: number;
+  completions?: number;
+  attempts?: number;
+  passing_epa?: number;
+  rushing_epa?: number;
+  receiving_epa?: number;
+  passing_tds?: number;
+  rushing_tds?: number;
+  receiving_tds?: number;
+  interceptions?: number;
+  sacks?: number;
+  targets?: number;
+  receptions?: number;
+  [key: string]: unknown;
+}
+
+function lookupPlayerStatsJson(player: string, season: number): PlayerStatData | null {
+  const cache = getGlobalCache();
+  const key = playerStatsCacheKey(player, season);
+  return cache.getOrFetch<PlayerStatData>(key, () => {
+    const raw = runPythonQuery('query_player_epa.py', [
+      '--player', player,
+      '--season', String(season),
+    ]);
+    if (!raw) return null;
+    try {
+      const parsed = JSON.parse(raw);
+      // The script may return an array or an object
+      if (Array.isArray(parsed)) return parsed[0] ?? null;
+      return parsed as PlayerStatData;
+    } catch {
+      return null;
+    }
+  }, DEFAULT_TTL.playerStats ?? 3600);
+}
+
+/** Map claim metrics to nflverse stat fields. */
+const METRIC_MAP: Record<string, (d: PlayerStatData) => number | undefined> = {
+  'passing_yards': d => d.passing_yards,
+  'rushing_yards': d => d.rushing_yards,
+  'receiving_yards': d => d.receiving_yards,
+  'touchdowns': d => {
+    const p = d.passing_tds ?? 0;
+    const ru = d.rushing_tds ?? 0;
+    const re = d.receiving_tds ?? 0;
+    return p + ru + re;
+  },
+  'interceptions': d => d.interceptions,
+  'sacks': d => d.sacks,
+  'EPA': d => d.passing_epa ?? d.rushing_epa ?? d.receiving_epa,
+  'completion_pct': d => {
+    if (d.completions != null && d.attempts != null && d.attempts > 0) {
+      return (d.completions / d.attempts) * 100;
+    }
+    return undefined;
+  },
+  'cpoe': d => d.passing_epa, // Approximate — CPOE isn't directly in basic stats
+  'target_share': d => {
+    // target_share is usually a team-relative metric, not available in basic player stats
+    return undefined;
+  },
+  'passer_rating': d => {
+    // Passer rating needs calculation — skip for now, flag as unverifiable
+    return undefined;
+  },
+  'tackles': d => d.tackles as number | undefined,
+  'success_rate': d => undefined, // Team-level metric
+};
+
+/**
+ * Cross-reference statistical claims against nflverse data.
+ * Returns a validation result for each claim where data is available.
+ */
+export function validateStatClaims(claims: ExtractedClaims): ValidationResult[] {
+  const season = currentSeason();
+  const results: ValidationResult[] = [];
+
+  for (const claim of claims.statClaims) {
+    const stats = lookupPlayerStatsJson(claim.player, season);
+    if (!stats) {
+      results.push({
+        claim: `${claim.player}: ${claim.metric} = ${claim.value}`,
+        verified: false,
+        actual: 'No nflverse data found',
+        source: 'query_player_epa.py',
+      });
+      continue;
+    }
+
+    const extractor = METRIC_MAP[claim.metric];
+    if (!extractor) {
+      results.push({
+        claim: `${claim.player}: ${claim.metric} = ${claim.value}`,
+        verified: false,
+        actual: `Metric '${claim.metric}' not available for deterministic check`,
+        source: 'query_player_epa.py',
+      });
+      continue;
+    }
+
+    const actualValue = extractor(stats);
+    if (actualValue === undefined) {
+      results.push({
+        claim: `${claim.player}: ${claim.metric} = ${claim.value}`,
+        verified: false,
+        actual: 'Metric not available in player data',
+        source: 'query_player_epa.py',
+      });
+      continue;
+    }
+
+    const claimedNumeric = parseFloat(claim.value.replace(/,/g, ''));
+    const tolerance = Math.abs(actualValue) * 0.1 || 5; // 10% tolerance or ±5
+    const isClose = Math.abs(claimedNumeric - actualValue) <= tolerance;
+
+    results.push({
+      claim: `${claim.player}: ${claim.metric} = ${claim.value}`,
+      verified: isClose,
+      actual: `nflverse: ${actualValue}`,
+      source: 'query_player_epa.py',
+    });
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Draft validation
+// ---------------------------------------------------------------------------
+
+interface DraftData {
+  player_name?: string;
+  pfr_player_name?: string;
+  round?: number;
+  pick?: number;
+  season?: number;
+  team?: string;
+  [key: string]: unknown;
+}
+
+function lookupDraftData(player: string): DraftData | null {
+  const cache = getGlobalCache();
+  const key = draftHistoryCacheKey([player.toLowerCase()]);
+  return cache.getOrFetch<DraftData>(key, () => {
+    const raw = runPythonQuery('query_draft_value.py', [
+      '--player', player,
+    ]);
+    if (!raw) return null;
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) return parsed[0] ?? null;
+      return parsed as DraftData;
+    } catch {
+      return null;
+    }
+  }, DEFAULT_TTL.draftHistory);
+}
+
+/**
+ * Verify draft claims (pick number, round, year) against nflverse draft history.
+ */
+export function validateDraftClaims(claims: ExtractedClaims): ValidationResult[] {
+  const results: ValidationResult[] = [];
+
+  for (const claim of claims.draftClaims) {
+    const draft = lookupDraftData(claim.player);
+    if (!draft) {
+      results.push({
+        claim: claim.raw,
+        verified: false,
+        actual: 'No draft data found in nflverse',
+        source: 'query_draft_value.py',
+      });
+      continue;
+    }
+
+    const mismatches: string[] = [];
+
+    if (claim.round != null && draft.round != null && claim.round !== draft.round) {
+      mismatches.push(`round: claimed ${claim.round}, actual ${draft.round}`);
+    }
+    if (claim.pick != null && draft.pick != null && claim.pick !== draft.pick) {
+      mismatches.push(`pick: claimed ${claim.pick}, actual ${draft.pick}`);
+    }
+    if (claim.year != null && draft.season != null && claim.year !== draft.season) {
+      mismatches.push(`year: claimed ${claim.year}, actual ${draft.season}`);
+    }
+
+    const actualParts: string[] = [];
+    if (draft.round) actualParts.push(`round ${draft.round}`);
+    if (draft.pick) actualParts.push(`pick ${draft.pick}`);
+    if (draft.season) actualParts.push(`${draft.season} draft`);
+    if (draft.team) actualParts.push(`by ${draft.team}`);
+
+    results.push({
+      claim: claim.raw,
+      verified: mismatches.length === 0,
+      actual: mismatches.length > 0
+        ? `MISMATCH: ${mismatches.join('; ')} (nflverse: ${actualParts.join(', ')})`
+        : `Confirmed: ${actualParts.join(', ')}`,
+      source: 'query_draft_value.py',
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Build a markdown validation report from stat and draft validation results.
+ */
+export function buildValidationReport(
+  statResults: ValidationResult[],
+  draftResults: ValidationResult[],
+): string {
+  const lines: string[] = ['## Pre-Publish Fact Validation', ''];
+
+  const allResults = [...statResults, ...draftResults];
+  const verified = allResults.filter(r => r.verified);
+  const flagged = allResults.filter(r => !r.verified);
+
+  if (flagged.length > 0) {
+    lines.push('### ⚠️ Flagged Claims');
+    for (const r of flagged) {
+      const icon = r.actual.includes('MISMATCH') ? '🔴' : '⚠️';
+      lines.push(`- ${icon} **${r.claim}** — ${r.actual} *(${r.source})*`);
+    }
+    lines.push('');
+  }
+
+  if (verified.length > 0) {
+    lines.push('### ✅ Verified Claims');
+    for (const r of verified) {
+      lines.push(`- ✅ **${r.claim}** — ${r.actual}`);
+    }
+    lines.push('');
+  }
+
+  if (allResults.length === 0) {
+    lines.push('*No verifiable statistical or draft claims found in the article.*');
+    lines.push('');
+  }
+
+  lines.push(`*${verified.length}/${allResults.length} claims verified against nflverse data.*`);
+
+  return lines.join('\n');
+}

--- a/tests/pipeline/claim-extractor.test.ts
+++ b/tests/pipeline/claim-extractor.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractClaims,
+  extractClaimedPlayers,
+  totalClaimCount,
+  type ExtractedClaims,
+} from '../../src/pipeline/claim-extractor.js';
+
+// ---------------------------------------------------------------------------
+// Test data — sample panel markdown containing various claim types
+// ---------------------------------------------------------------------------
+
+const SAMPLE_PANEL = `
+## SEA — Seahawks Team Context
+
+The Seahawks are in an interesting position this offseason. **Sam Darnold** has posted a solid
++0.12 EPA per dropback since arriving, which ranks among the top 15 quarterbacks in the league.
+He threw for 3,200 passing yards and 22 touchdowns against 14 interceptions. His completion
+percentage of 65.8% completion rate is respectable but not elite.
+
+**Kenneth Walker III** contributed 1,050 rushing yards and the team's run game saw a 42.5% success rate.
+
+**Jaxon Smith-Njigba** finished with 1,120 receiving yards and a 24.3% target share, ranking him
+as a top 10 receiver by target volume.
+
+## Cap — Salary Cap Analysis
+
+The extension for **Devon Witherspoon** is expected to cost $19.5 million per year on a
+5-year deal worth roughly $98 million. The cap hit in year one would be approximately
+$12 million cap hit, with dead money protections kicking in after year 3.
+
+**Leonard Williams** carries a $22 million cap hit this season.
+
+## Draft — Historical Context
+
+**Jaxon Smith-Njigba** was selected in round 1, pick 20 overall of the 2023 NFL Draft.
+He was a 1st-round pick who has outperformed most receivers taken in that range.
+
+**Kenneth Walker III**, a 2nd-round pick drafted in round 2 of the 2022 draft, has been
+a solid contributor. He was the No. 41 overall pick.
+
+**Devon Witherspoon** was the No. 5 overall pick in the 2023 NFL Draft and quickly became
+one of the best cornerbacks in football.
+
+## Analytics — Advanced Metrics
+
+**Sam Darnold** posted a +2.5 CPOE and an 88.4 passer rating. Among qualified starters,
+he ranked #12 in passing EPA. His performance was the best in the NFL among mid-tier
+quarterback contracts.
+
+**Leonard Williams** recorded 7.5 sacks and led the league in pressures among interior
+defensive linemen. He had 52 total tackles on the season.
+`;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('claim-extractor', () => {
+  describe('extractClaims', () => {
+    let claims: ExtractedClaims;
+
+    // Extract once, test many
+    claims = extractClaims(SAMPLE_PANEL);
+
+    it('extracts statistical claims', () => {
+      expect(claims.statClaims.length).toBeGreaterThan(0);
+
+      // Check for specific stat claims (name must appear in the same sentence)
+      const epa = claims.statClaims.find(c => c.player === 'Sam Darnold' && c.metric === 'EPA');
+      expect(epa).toBeDefined();
+
+      // "He threw for 3,200 passing yards" uses pronoun — not extractable from SAMPLE.
+      // Verify direct name references work:
+      const directClaims = extractClaims('Sam Darnold threw for 3,200 passing yards this season.');
+      const passingYards = directClaims.statClaims.find(c =>
+        c.player === 'Sam Darnold' && c.metric === 'passing_yards',
+      );
+      expect(passingYards).toBeDefined();
+      expect(passingYards?.value).toContain('3,200');
+
+      const rushYards = claims.statClaims.find(c =>
+        c.player === 'Kenneth Walker III' && c.metric === 'rushing_yards',
+      );
+      expect(rushYards).toBeDefined();
+
+      const recYards = claims.statClaims.find(c =>
+        c.player === 'Jaxon Smith-Njigba' && c.metric === 'receiving_yards',
+      );
+      expect(recYards).toBeDefined();
+    });
+
+    it('extracts touchdown claims when name is in same sentence', () => {
+      // In SAMPLE, "He threw for...22 touchdowns" uses pronoun — not extractable.
+      // Direct name reference works:
+      const directClaims = extractClaims('Sam Darnold threw for 22 touchdowns this season.');
+      const tds = directClaims.statClaims.find(c =>
+        c.player === 'Sam Darnold' && c.metric === 'touchdowns',
+      );
+      expect(tds).toBeDefined();
+      expect(tds?.value).toBe('22');
+    });
+
+    it('extracts interception claims when name is adjacent', () => {
+      // In the sample, "He threw for ... 14 interceptions" uses a pronoun.
+      // Direct name reference works:
+      const directText = 'Sam Darnold threw for 3,200 passing yards and 22 touchdowns against 14 interceptions.';
+      const directClaims = extractClaims(directText);
+      const ints = directClaims.statClaims.find(c =>
+        c.player === 'Sam Darnold' && c.metric === 'interceptions',
+      );
+      expect(ints).toBeDefined();
+      expect(ints?.value).toBe('14');
+    });
+
+    it('extracts sack claims', () => {
+      const sacks = claims.statClaims.find(c =>
+        c.player === 'Leonard Williams' && c.metric === 'sacks',
+      );
+      expect(sacks).toBeDefined();
+      expect(sacks?.value).toBe('7.5');
+    });
+
+    it('extracts target share claims', () => {
+      const ts = claims.statClaims.find(c =>
+        c.player === 'Jaxon Smith-Njigba' && c.metric === 'target_share',
+      );
+      expect(ts).toBeDefined();
+      expect(ts?.value).toBe('24.3');
+    });
+
+    it('extracts CPOE claims', () => {
+      const cpoe = claims.statClaims.find(c =>
+        c.player === 'Sam Darnold' && c.metric === 'cpoe',
+      );
+      expect(cpoe).toBeDefined();
+    });
+
+    it('extracts tackle claims when name is adjacent', () => {
+      // Note: "He had 52 tackles" uses a pronoun, not a name — not extractable.
+      // But "Leonard Williams recorded 52 tackles" would be.
+      const directText = 'Leonard Williams recorded 52 total tackles this season.';
+      const directClaims = extractClaims(directText);
+      const tackles = directClaims.statClaims.find(c =>
+        c.player === 'Leonard Williams' && c.metric === 'tackles',
+      );
+      expect(tackles).toBeDefined();
+      expect(tackles?.value).toBe('52');
+    });
+
+    it('extracts contract claims', () => {
+      expect(claims.contractClaims.length).toBeGreaterThan(0);
+
+      const witherspoonContract = claims.contractClaims.find(c =>
+        c.player === 'Devon Witherspoon',
+      );
+      expect(witherspoonContract).toBeDefined();
+    });
+
+    it('extracts draft claims', () => {
+      expect(claims.draftClaims.length).toBeGreaterThan(0);
+
+      const jsnDraft = claims.draftClaims.find(c =>
+        c.player === 'Jaxon Smith-Njigba',
+      );
+      expect(jsnDraft).toBeDefined();
+      if (jsnDraft?.round) expect(jsnDraft.round).toBe(1);
+      if (jsnDraft?.pick) expect(jsnDraft.pick).toBe(20);
+
+      const walker = claims.draftClaims.find(c =>
+        c.player === 'Kenneth Walker III',
+      );
+      expect(walker).toBeDefined();
+
+      const witherspoon = claims.draftClaims.find(c =>
+        c.player === 'Devon Witherspoon',
+      );
+      expect(witherspoon).toBeDefined();
+      if (witherspoon?.pick) expect(witherspoon.pick).toBe(5);
+    });
+
+    it('extracts performance/ranking claims', () => {
+      expect(claims.performanceClaims.length).toBeGreaterThan(0);
+
+      // "top 15" / "top 10" / "ranked #12" / "led the league" / "best in the NFL"
+      const hasRanking = claims.performanceClaims.some(c =>
+        c.raw.toLowerCase().includes('top') ||
+        c.raw.toLowerCase().includes('ranked') ||
+        c.raw.toLowerCase().includes('led the league') ||
+        c.raw.toLowerCase().includes('best in the nfl'),
+      );
+      expect(hasRanking).toBe(true);
+    });
+  });
+
+  describe('extractClaimedPlayers', () => {
+    it('returns unique player names across all claim types', () => {
+      const claims = extractClaims(SAMPLE_PANEL);
+      const players = extractClaimedPlayers(claims);
+
+      expect(players).toContain('Sam Darnold');
+      expect(players).toContain('Kenneth Walker III');
+      expect(players).toContain('Jaxon Smith-Njigba');
+      expect(players).toContain('Devon Witherspoon');
+      expect(players).toContain('Leonard Williams');
+
+      // No duplicates
+      expect(new Set(players).size).toBe(players.length);
+    });
+  });
+
+  describe('totalClaimCount', () => {
+    it('sums claims across all categories', () => {
+      const claims = extractClaims(SAMPLE_PANEL);
+      const total = totalClaimCount(claims);
+
+      expect(total).toBeGreaterThan(10); // Should have many claims from the sample
+      expect(total).toBe(
+        claims.statClaims.length +
+        claims.contractClaims.length +
+        claims.draftClaims.length +
+        claims.performanceClaims.length,
+      );
+    });
+
+    it('returns 0 for text with no claims', () => {
+      const claims = extractClaims('This is a plain text article about the offseason with no statistics.');
+      expect(totalClaimCount(claims)).toBe(0);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles empty input', () => {
+      const claims = extractClaims('');
+      expect(totalClaimCount(claims)).toBe(0);
+    });
+
+    it('handles text with no player names', () => {
+      const claims = extractClaims('The team needs to improve their 45.2% success rate and reduce the 3.5 sacks per game.');
+      expect(claims.statClaims.length).toBe(0);
+    });
+
+    it('handles players with suffixes (Jr., III)', () => {
+      const text = '**Kenneth Walker III** rushed for 1,050 rushing yards. **Odell Beckham Jr.** had 500 receiving yards.';
+      const claims = extractClaims(text);
+
+      const walker = claims.statClaims.find(c => c.player === 'Kenneth Walker III');
+      expect(walker).toBeDefined();
+    });
+
+    it('deduplicates identical claims', () => {
+      const text = '**Sam Darnold** threw for 3,200 passing yards. As mentioned, **Sam Darnold** had 3,200 passing yards.';
+      const claims = extractClaims(text);
+      const passingYardsClaims = claims.statClaims.filter(c =>
+        c.player === 'Sam Darnold' && c.metric === 'passing_yards',
+      );
+      expect(passingYardsClaims.length).toBe(1);
+    });
+  });
+});

--- a/tests/pipeline/validators.test.ts
+++ b/tests/pipeline/validators.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  validateStatClaims,
+  validateDraftClaims,
+  buildValidationReport,
+} from '../../src/pipeline/validators.js';
+import { extractClaims } from '../../src/pipeline/claim-extractor.js';
+import * as childProcess from 'node:child_process';
+
+// ---------------------------------------------------------------------------
+// Mock child_process.execFileSync (same pattern as roster-context.test.ts)
+// ---------------------------------------------------------------------------
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...orig,
+    execFileSync: vi.fn(),
+  };
+});
+
+const mockExecFileSync = vi.mocked(childProcess.execFileSync);
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const PLAYER_STATS_DARNOLD = JSON.stringify({
+  player_display_name: 'Sam Darnold',
+  passing_yards: 3180,
+  passing_tds: 21,
+  rushing_tds: 2,
+  interceptions: 14,
+  completions: 280,
+  attempts: 430,
+  passing_epa: 0.11,
+});
+
+const PLAYER_STATS_WALKER = JSON.stringify({
+  player_display_name: 'Kenneth Walker III',
+  rushing_yards: 1020,
+  rushing_tds: 8,
+  rushing_epa: 0.05,
+});
+
+const DRAFT_DATA_JSN = JSON.stringify({
+  player_name: 'Jaxon Smith-Njigba',
+  round: 1,
+  pick: 20,
+  season: 2023,
+  team: 'SEA',
+});
+
+const DRAFT_DATA_WALKER = JSON.stringify({
+  player_name: 'Kenneth Walker III',
+  round: 2,
+  pick: 41,
+  season: 2022,
+  team: 'SEA',
+});
+
+const DRAFT_DATA_WITHERSPOON = JSON.stringify({
+  player_name: 'Devon Witherspoon',
+  round: 1,
+  pick: 5,
+  season: 2023,
+  team: 'SEA',
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('validators', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('validateStatClaims', () => {
+    it('validates passing yards within tolerance', () => {
+      const text = '**Sam Darnold** threw for 3,200 passing yards and 22 touchdowns.';
+      const claims = extractClaims(text);
+
+      // Mock: player stats query
+      mockExecFileSync.mockReturnValueOnce(PLAYER_STATS_DARNOLD as any);
+      // For the TD claim, same player already cached or re-queried
+      mockExecFileSync.mockReturnValueOnce(PLAYER_STATS_DARNOLD as any);
+
+      const results = validateStatClaims(claims);
+
+      // Passing yards: claimed 3200, actual 3180 — within 10% tolerance
+      const yardResult = results.find(r => r.claim.includes('passing_yards'));
+      expect(yardResult).toBeDefined();
+      expect(yardResult!.verified).toBe(true);
+    });
+
+    it('flags stats that exceed tolerance', () => {
+      const text = '**Sam Darnold** threw for 5,000 passing yards this season.';
+      const claims = extractClaims(text);
+
+      mockExecFileSync.mockReturnValueOnce(PLAYER_STATS_DARNOLD as any);
+
+      const results = validateStatClaims(claims);
+
+      const yardResult = results.find(r => r.claim.includes('passing_yards'));
+      expect(yardResult).toBeDefined();
+      expect(yardResult!.verified).toBe(false);
+      expect(yardResult!.actual).toContain('3180');
+    });
+
+    it('handles missing player data gracefully', () => {
+      const text = '**Unknown Player** threw for 4,000 passing yards.';
+      const claims = extractClaims(text);
+
+      mockExecFileSync.mockImplementation(() => { throw new Error('not found'); });
+
+      const results = validateStatClaims(claims);
+
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].verified).toBe(false);
+      expect(results[0].actual).toContain('No nflverse data');
+    });
+
+    it('validates rushing yards', () => {
+      const text = '**Kenneth Walker III** rushed for 1,050 rushing yards.';
+      const claims = extractClaims(text);
+
+      mockExecFileSync.mockReturnValueOnce(PLAYER_STATS_WALKER as any);
+
+      const results = validateStatClaims(claims);
+
+      const rushResult = results.find(r => r.claim.includes('rushing_yards'));
+      expect(rushResult).toBeDefined();
+      // 1050 vs 1020: difference of 30, tolerance is 102 (10% of 1020) — should pass
+      expect(rushResult!.verified).toBe(true);
+    });
+  });
+
+  describe('validateDraftClaims', () => {
+    it('verifies correct draft information', () => {
+      const text = '**Jaxon Smith-Njigba** was selected in round 1 as the No. 20 overall pick in the 2023 draft.';
+      const claims = extractClaims(text);
+
+      mockExecFileSync.mockReturnValue(DRAFT_DATA_JSN as any);
+
+      const results = validateDraftClaims(claims);
+
+      expect(results.length).toBeGreaterThan(0);
+      const jsnResult = results.find(r => r.claim.includes('Jaxon Smith-Njigba'));
+      expect(jsnResult).toBeDefined();
+      expect(jsnResult!.verified).toBe(true);
+      expect(jsnResult!.actual).toContain('Confirmed');
+    });
+
+    it('flags incorrect round', () => {
+      const text = '**Jaxon Smith-Njigba**, a 2nd-round pick who has outperformed expectations.';
+      const claims = extractClaims(text);
+
+      mockExecFileSync.mockReturnValue(DRAFT_DATA_JSN as any);
+
+      const results = validateDraftClaims(claims);
+
+      const jsnResult = results.find(r => r.claim.includes('Jaxon Smith-Njigba'));
+      expect(jsnResult).toBeDefined();
+      expect(jsnResult!.verified).toBe(false);
+      expect(jsnResult!.actual).toContain('MISMATCH');
+      expect(jsnResult!.actual).toContain('round');
+    });
+
+    it('flags incorrect pick number', () => {
+      const text = '**Devon Witherspoon** was the No. 10 overall pick in the 2023 NFL Draft.';
+      const claims = extractClaims(text);
+
+      mockExecFileSync.mockReturnValue(DRAFT_DATA_WITHERSPOON as any);
+
+      const results = validateDraftClaims(claims);
+
+      const result = results.find(r => r.claim.includes('Devon Witherspoon'));
+      expect(result).toBeDefined();
+      expect(result!.verified).toBe(false);
+      expect(result!.actual).toContain('MISMATCH');
+      expect(result!.actual).toContain('pick');
+    });
+
+    it('handles missing draft data gracefully', () => {
+      const text = '**Unknown Prospect** was a 1st-round pick in the 2024 NFL Draft.';
+      const claims = extractClaims(text);
+
+      mockExecFileSync.mockImplementation(() => { throw new Error('not found'); });
+
+      const results = validateDraftClaims(claims);
+
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].verified).toBe(false);
+      expect(results[0].actual).toContain('No draft data');
+    });
+
+    it('verifies correct pick for Walker', () => {
+      const text = '**Kenneth Walker III** was the No. 41 overall pick in the 2022 draft.';
+      const claims = extractClaims(text);
+
+      mockExecFileSync.mockReturnValue(DRAFT_DATA_WALKER as any);
+
+      const results = validateDraftClaims(claims);
+
+      const walkerResult = results.find(r => r.claim.includes('Kenneth Walker'));
+      expect(walkerResult).toBeDefined();
+      expect(walkerResult!.verified).toBe(true);
+    });
+  });
+
+  describe('buildValidationReport', () => {
+    it('builds a markdown report with flagged and verified sections', () => {
+      const statResults = [
+        { claim: 'Sam Darnold: passing_yards = 3,200', verified: true, actual: 'nflverse: 3180', source: 'query_player_epa.py' },
+        { claim: 'Sam Darnold: touchdowns = 50', verified: false, actual: 'nflverse: 21', source: 'query_player_epa.py' },
+      ];
+      const draftResults = [
+        { claim: 'JSN round 1, pick 20', verified: true, actual: 'Confirmed: round 1, pick 20, 2023 draft', source: 'query_draft_value.py' },
+        { claim: 'Walker round 3', verified: false, actual: 'MISMATCH: round: claimed 3, actual 2', source: 'query_draft_value.py' },
+      ];
+
+      const report = buildValidationReport(statResults, draftResults);
+
+      expect(report).toContain('Pre-Publish Fact Validation');
+      expect(report).toContain('Flagged Claims');
+      expect(report).toContain('Verified Claims');
+      expect(report).toContain('🔴'); // MISMATCH gets 🔴
+      expect(report).toContain('⚠️'); // Non-mismatch failures get ⚠️
+      expect(report).toContain('✅');
+      expect(report).toContain('2/4 claims verified');
+    });
+
+    it('handles all-verified case', () => {
+      const results = [
+        { claim: 'test', verified: true, actual: 'confirmed', source: 'test' },
+      ];
+      const report = buildValidationReport(results, []);
+
+      expect(report).toContain('Verified Claims');
+      expect(report).not.toContain('Flagged Claims');
+      expect(report).toContain('1/1 claims verified');
+    });
+
+    it('handles no claims', () => {
+      const report = buildValidationReport([], []);
+
+      expect(report).toContain('No verifiable');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements **K5a wire fact checking into pipeline** (issue #83).

### What changed

**New modules:**
- \claim-extractor.ts\ — regex-based extraction of stat, contract, draft, and performance claims from markdown
- \act-check-context.ts\ — queries nflverse Python scripts, builds enriched fact-check artifact (follows roster-context.ts architecture)
- \alidators.ts\ — deterministic stat validation (10% tolerance) and draft validation (round/pick/year) against nflverse data

**Pipeline wiring (actions.ts):**
- **writeDraft (Stage 4→5):** extract claims from panel outputs → build nflverse context → inject into LLM fact-check prompt
- **runEditor (Stage 5→6):** include \act-check-context.md\ artifact in editor context
- **runPublisherPass (Stage 6→7):** run deterministic validators → write \act-validation.md\ artifact

**context-config.ts:** Added \act-check-context.md\ to writeDraft and runEditor include lists.

### Tests
- 29 new tests (17 claim-extractor, 12 validators)
- All 1315 tests pass ✅

### Design decisions
- Regex-based claim extraction (no LLM calls) — lightweight and deterministic
- Graceful degradation: if Python scripts fail or return no data, pipeline continues normally
- Cache-aware: uses existing \getGlobalCache()\ with \DEFAULT_TTL.playerStats\ (4h) and \DEFAULT_TTL.draftHistory\ (24h)

Closes #83