### PR TITLE
test: lock copilot-cli usage path

### DIFF
--- a/.squad/agents/code/history.md
+++ b/.squad/agents/code/history.md
@@ -57,3 +57,24 @@
 - Decision inbox merge completed for the static knowledge-asset pass, and older decision history moved to the archive file.
 - The planning record now emphasizes the proof-of-concept content layer plus validation/docs, not runner or pipeline integration.
 - Continue treating runtime injection and refresh automation as deferred follow-up work.
+
+### 2026-03-22T19-10-00Z: Issue #85 structure validation completion
+- Standardized the glossary seeds on a shared YAML shape with explicit `id`, `glossary`, freshness metadata, and entry-level source refs.
+- Standardized the proof-of-concept team sheets on YAML frontmatter plus fixed markdown headings (`Durable snapshot`, `Identity anchors`, `Roster-building and cap framing`, `Source guidance`).
+- Vitest coverage now parses the glossary YAML directly and validates team-sheet frontmatter/body structure without touching runtime prompt assembly.
+
+### 2026-03-22: Debug visibility restore
+
+**What:** Restored the collapsible artifact thinking/debug section on article artifact views by loading companion `*.thinking.md` artifacts when the main `*.md` artifact is rendered.
+
+**Why:** The historical inline `<think>` collapse UI survived, but Issue #88-era pipeline changes persist thinking separately via `writeAgentResult()` in `src/pipeline/actions.ts`, so normal artifact views stopped showing the debug section unless you clicked the dedicated 💭 tab.
+
+**Key implementation choice:** Treat persisted `*.thinking.md` files as the authoritative debug source for the main artifact view, fall back to inline token extraction only for legacy artifacts, and avoid conversation logs because they store cleaned assistant outputs rather than full thinking traces.
+
+**Validation:** `npm run v2:build` passed, and targeted Vitest coverage passed for `tests/dashboard/wave2.test.ts`, `tests/dashboard/server.test.ts`, `tests/dashboard/extract-thinking.test.ts`, and `tests/pipeline/write-agent-result.test.ts`.
+
+### 2026-03-22: Issue #93 Copilot CLI token-usage trace
+
+- I could not reproduce a runtime rendering bug on current `main`: the article detail page and HTMX live sidebar already render `usage_events` rows for `copilot-cli` the same way they do for other providers.
+- The real gap was regression coverage across the full chain: provider `usage` → `AgentRunner.tokensUsed` → `recordAgentUsage()` persistence → article-page/live-sidebar rendering.
+- Added focused tests in `tests/agents/runner.test.ts`, `tests/pipeline/actions.test.ts`, and `tests/dashboard/server.test.ts` to lock down the Copilot CLI path and confirm `copilot-cli` appears in the provider breakdown when usage rows exist.

--- a/.squad/decisions/inbox/code-issue93-token-usage.md
+++ b/.squad/decisions/inbox/code-issue93-token-usage.md
@@ -1,0 +1,33 @@
+---
+
+# Decision: Treat `usage_events` as the sole source of truth for article token usage
+
+**Issue:** #93 — Bug: article page missing token usage for Copilot CLI provider
+**Status:** IMPLEMENTED
+**Submitted by:** Code (🔧 Dev)
+**Date:** 2026-03-22
+
+---
+
+## TLDR
+
+Do not add Copilot CLI-specific dashboard logic for article usage. The article detail page and HTMX live sidebar should continue to render strictly from persisted `usage_events`, with Copilot CLI covered by the same provider → runner → persistence pipeline as every other LLM provider.
+
+## Decision
+
+For issue #93, the durable fix is to lock down the existing shared usage path with focused regression tests:
+
+- provider `usage` returned by `src/llm/providers/copilot-cli.ts`
+- mapped to `AgentRunner.tokensUsed` in `src/agents/runner.ts`
+- persisted via `recordAgentUsage()` in `src/pipeline/actions.ts`
+- rendered from `repo.getUsageEvents()` by the article detail page and live sidebar in `src/dashboard/server.ts` / `src/dashboard/views/article.ts`
+
+## Why
+
+- Current dashboard rendering is provider-agnostic already; it only needs persisted `usage_events` rows.
+- Adding a Copilot CLI-specific UI fallback would duplicate state and hide real persistence regressions.
+- The missing protection was end-to-end test coverage, not a separate rendering path.
+
+## Operational rule
+
+When a provider-specific usage bug is reported on the article page, first verify the shared trace (`provider response → runner → usage_events → article renderer`) before adding any dashboard branching. Prefer layered regression tests over special-case rendering.

--- a/src/llm/providers/copilot-cli.ts
+++ b/src/llm/providers/copilot-cli.ts
@@ -11,7 +11,7 @@
  *   + Access to all Copilot-supported models via --model flag
  *   + Built-in tool use, context, and safety features
  *   - Higher latency (~5-10s overhead per call for CLI startup)
- *   - No streaming, no token usage stats
+ *   - No streaming or exact token usage stats (returns estimates instead)
  *   - No structured output (response_format: json is best-effort)
  *   - Output is plain text (may include markdown formatting)
  */
@@ -191,7 +191,7 @@ export class CopilotCLIProvider implements LLMProvider {
       content,
       model,
       provider: this.id,
-      // CLI doesn't expose token usage — estimate from character counts.
+      // CLI doesn't expose exact token usage — estimate from character counts.
       // ~4 characters per token is a standard approximation.
       usage: {
         promptTokens: Math.ceil(prompt.length / 4),

--- a/tests/agents/runner.test.ts
+++ b/tests/agents/runner.test.ts
@@ -9,7 +9,12 @@ import {
   type AgentRunParams,
 } from '../../src/agents/runner.js';
 import { AgentMemory, type MemoryEntry } from '../../src/agents/memory.js';
-import { LLMGateway } from '../../src/llm/gateway.js';
+import {
+  LLMGateway,
+  type ChatRequest,
+  type ChatResponse,
+  type LLMProvider,
+} from '../../src/llm/gateway.js';
 import { StubProvider } from '../../src/llm/providers/stub.js';
 import { ModelPolicy } from '../../src/llm/model-policy.js';
 
@@ -104,6 +109,33 @@ function createTempFixtures() {
   writeFileSync(join(skillsDir, 'data-visualization.md'), DATA_VIZ_SKILL);
 
   return { tempDir, chartersDir, skillsDir, dbPath };
+}
+
+class CopilotCliUsageProvider implements LLMProvider {
+  readonly id = 'copilot-cli';
+  readonly name = 'GitHub Copilot CLI';
+
+  chat(request: ChatRequest): Promise<ChatResponse> {
+    return Promise.resolve({
+      content: 'Estimated usage response',
+      model: request.model ?? 'gpt-5.4',
+      provider: this.id,
+      usage: {
+        promptTokens: 321,
+        completionTokens: 123,
+        totalTokens: 444,
+      },
+      finishReason: 'stop',
+    });
+  }
+
+  listModels(): string[] {
+    return ['gpt-5.4', 'gpt-5-mini'];
+  }
+
+  supportsModel(model: string): boolean {
+    return model.startsWith('gpt-5');
+  }
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -613,6 +645,28 @@ describe('AgentRunner', () => {
       expect(result.tokensUsed).toBeDefined();
       expect(result.tokensUsed!.prompt).toBe(0);
       expect(result.tokensUsed!.completion).toBe(0);
+    });
+
+    it('maps estimated copilot-cli usage into tokensUsed', async () => {
+      const copilotGateway = new LLMGateway({
+        modelPolicy: loadPolicy(),
+        providers: [new CopilotCliUsageProvider()],
+      });
+      const copilotRunner = new AgentRunner({
+        gateway: copilotGateway,
+        memory,
+        chartersDir,
+        skillsDir,
+      });
+
+      const result = await copilotRunner.run({
+        agentName: 'writer',
+        task: 'Write a short piece',
+      });
+
+      expect(result.provider).toBe('copilot-cli');
+      expect(result.model).toMatch(/^gpt-5/);
+      expect(result.tokensUsed).toEqual({ prompt: 321, completion: 123 });
     });
   });
 });

--- a/tests/dashboard/server.test.ts
+++ b/tests/dashboard/server.test.ts
@@ -95,6 +95,29 @@ describe('Dashboard Server', () => {
       expect(html).toContain('/htmx/articles/detail-test/context-config');
     });
 
+    it('article detail page shows copilot-cli provider usage when usage rows exist', async () => {
+      repo.createArticle({ id: 'detail-copilot', title: 'Detail Copilot Article' });
+      repo.recordUsageEvent({
+        articleId: 'detail-copilot',
+        stage: 5,
+        surface: 'writeDraft',
+        provider: 'copilot-cli',
+        eventType: 'completed',
+        modelOrTool: 'gpt-5.4',
+        promptTokens: 4321,
+        outputTokens: 987,
+        costUsdEstimate: 0.02,
+      });
+
+      const res = await app.request('/articles/detail-copilot');
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain('Token Usage');
+      expect(html).toContain('By Provider');
+      expect(html).toContain('copilot-cli');
+      expect(html).toContain('5.3k');
+    });
+
     it('article detail returns 404 for missing article', async () => {
       const res = await app.request('/articles/nonexistent');
       expect(res.status).toBe(404);
@@ -250,6 +273,29 @@ describe('Dashboard Server', () => {
       const html = await res.text();
       expect(html).toContain('Pub Ready');
       expect(html).toContain('card-ready');
+    });
+
+    it('GET /htmx/articles/:id/live-sidebar matches copilot-cli usage state', async () => {
+      repo.createArticle({ id: 'sidebar-copilot', title: 'Sidebar Copilot Article' });
+      repo.recordUsageEvent({
+        articleId: 'sidebar-copilot',
+        stage: 6,
+        surface: 'runEditor',
+        provider: 'copilot-cli',
+        eventType: 'completed',
+        modelOrTool: 'gpt-5.4',
+        promptTokens: 4000,
+        outputTokens: 1200,
+        costUsdEstimate: 0.018,
+      });
+
+      const res = await app.request('/htmx/articles/sidebar-copilot/live-sidebar');
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain('Token Usage');
+      expect(html).toContain('By Provider');
+      expect(html).toContain('copilot-cli');
+      expect(html).toContain('5.2k');
     });
 
     it('GET /htmx/recent-ideas returns HTML fragment', async () => {

--- a/tests/pipeline/actions.test.ts
+++ b/tests/pipeline/actions.test.ts
@@ -13,7 +13,12 @@ import { PipelineEngine } from '../../src/pipeline/engine.js';
 import { PipelineAuditor } from '../../src/pipeline/audit.js';
 import { AgentRunner } from '../../src/agents/runner.js';
 import { AgentMemory } from '../../src/agents/memory.js';
-import { LLMGateway } from '../../src/llm/gateway.js';
+import {
+  LLMGateway,
+  type ChatRequest,
+  type ChatResponse,
+  type LLMProvider,
+} from '../../src/llm/gateway.js';
 import { StubProvider } from '../../src/llm/providers/stub.js';
 import { ModelPolicy } from '../../src/llm/model-policy.js';
 import type { AppConfig } from '../../src/config/index.js';
@@ -63,6 +68,33 @@ interface TestFixtures {
   memory: AgentMemory;
   config: AppConfig;
   ctx: ActionContext;
+}
+
+class CopilotCliUsageProvider implements LLMProvider {
+  readonly id = 'copilot-cli';
+  readonly name = 'GitHub Copilot CLI';
+
+  chat(request: ChatRequest): Promise<ChatResponse> {
+    return Promise.resolve({
+      content: '# Prompt\n\nEstimated Copilot CLI output.',
+      model: request.model ?? 'gpt-5.4',
+      provider: this.id,
+      usage: {
+        promptTokens: 432,
+        completionTokens: 210,
+        totalTokens: 642,
+      },
+      finishReason: 'stop',
+    });
+  }
+
+  listModels(): string[] {
+    return ['gpt-5.4', 'gpt-5-mini'];
+  }
+
+  supportsModel(model: string): boolean {
+    return model.startsWith('gpt-5');
+  }
 }
 
 function createFixtures(): TestFixtures {
@@ -123,6 +155,21 @@ function createFixtures(): TestFixtures {
     tempDir, articlesDir, chartersDir, skillsDir, logsDir,
     repo, engine, auditor, runner, memory, config, ctx,
   };
+}
+
+function setRunnerProvider(fixtures: TestFixtures, provider: LLMProvider): void {
+  const gateway = new LLMGateway({
+    modelPolicy: loadPolicy(),
+    providers: [provider],
+  });
+  const runner = new AgentRunner({
+    gateway,
+    memory: fixtures.memory,
+    chartersDir: fixtures.chartersDir,
+    skillsDir: fixtures.skillsDir,
+  });
+  fixtures.runner = runner;
+  fixtures.ctx.runner = runner;
 }
 
 function createArticleWithStage(
@@ -743,6 +790,23 @@ describe('Token usage recording', () => {
     const promptEvent = events.find(e => e.surface === 'generatePrompt');
     expect(promptEvent).toBeDefined();
     expect(promptEvent!.stage).toBe(1);
+  });
+
+  it('persists estimated copilot-cli usage into usage_events', async () => {
+    setRunnerProvider(fixtures, new CopilotCliUsageProvider());
+    createArticleWithStage(fixtures, 'test-usage-copilot', 1 as Stage, {
+      'idea.md': '# Great Idea\nAnalyze the Seahawks draft.',
+    });
+
+    const result = await STAGE_ACTIONS.generatePrompt('test-usage-copilot', fixtures.ctx);
+    expect(result.success).toBe(true);
+
+    const events = fixtures.repo.getUsageEvents('test-usage-copilot');
+    expect(events).toHaveLength(1);
+    expect(events[0].provider).toBe('copilot-cli');
+    expect(events[0].model_or_tool).toMatch(/^gpt-5/);
+    expect(events[0].prompt_tokens).toBe(432);
+    expect(events[0].output_tokens).toBe(210);
   });
 
   it('does not record usage when tokensUsed is undefined', () => {


### PR DESCRIPTION
## Summary\n- add regression coverage for the Copilot CLI usage handoff from provider response through runner and usage_events persistence\n- verify article detail and live-sidebar rendering both show copilot-cli in the Token Usage provider breakdown when usage rows exist\n- clarify in the Copilot CLI provider comments that token stats are estimated, not exact\n\n## Validation\n- npm run test -- --run tests/agents/runner.test.ts tests/pipeline/actions.test.ts tests/dashboard/server.test.ts tests/dashboard/wave2.test.ts tests/llm/provider-copilot-cli.test.ts\n- npm run v2:build\n- npm run test *(fails on an existing timeout in tests/dashboard/new-idea.test.ts:401)*\n\nCloses #93