### PR TITLE
fix: optimize article usage history query determinism

### DIFF
--- a/src/db/repository.ts
+++ b/src/db/repository.ts
@@ -167,13 +167,13 @@ export class Repository {
   getUsageEvents(articleId: string, limit?: number): UsageEvent[] {
     if (limit == null) {
       const stmt = this.db.prepare(
-        'SELECT * FROM usage_events WHERE article_id = ? ORDER BY created_at DESC',
+        'SELECT * FROM usage_events WHERE article_id = ? ORDER BY created_at DESC, id DESC',
       );
       return stmt.all(articleId) as unknown as UsageEvent[];
     }
 
     const stmt = this.db.prepare(
-      'SELECT * FROM usage_events WHERE article_id = ? ORDER BY created_at DESC LIMIT ?',
+      'SELECT * FROM usage_events WHERE article_id = ? ORDER BY created_at DESC, id DESC LIMIT ?',
     );
     return stmt.all(articleId, limit) as unknown as UsageEvent[];
   }

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -122,6 +122,9 @@ CREATE TABLE IF NOT EXISTS usage_events (
 CREATE INDEX IF NOT EXISTS idx_usage_events_article_stage
     ON usage_events(article_id, stage, created_at DESC);
 
+CREATE INDEX IF NOT EXISTS idx_usage_events_article_history
+    ON usage_events(article_id, created_at DESC, id DESC);
+
 CREATE INDEX IF NOT EXISTS idx_usage_events_stage_run
     ON usage_events(stage_run_id, created_at DESC);
 

--- a/tests/db/repository.test.ts
+++ b/tests/db/repository.test.ts
@@ -574,6 +574,48 @@ describe('Repository', () => {
       expect(limitedEvents.some((event) => event.provider === 'copilot-cli')).toBe(false);
     });
 
+    it('orders article usage history deterministically when timestamps tie', () => {
+      repo.createArticle({ id: 'ue-tie', title: 'Usage Tie Test' });
+
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date('2026-03-22T00:00:00Z'));
+        for (const surface of ['first', 'second', 'third']) {
+          repo.recordUsageEvent({
+            articleId: 'ue-tie',
+            stage: 5,
+            surface,
+            provider: 'anthropic',
+            modelOrTool: 'claude-sonnet-4',
+            promptTokens: 100,
+            outputTokens: 50,
+          });
+        }
+      } finally {
+        vi.useRealTimers();
+      }
+
+      expect(repo.getUsageEvents('ue-tie').map((event) => event.surface)).toEqual([
+        'third',
+        'second',
+        'first',
+      ]);
+      expect(repo.getUsageEvents('ue-tie', 2).map((event) => event.surface)).toEqual([
+        'third',
+        'second',
+      ]);
+    });
+
+    it('uses the article history index for full usage history reads', () => {
+      const plan = repo.getDb().prepare(
+        'EXPLAIN QUERY PLAN SELECT * FROM usage_events WHERE article_id = ? ORDER BY created_at DESC, id DESC',
+      ).all('ue-history') as Array<{ detail: string }>;
+
+      expect(
+        plan.some((row) => row.detail.includes('idx_usage_events_article_history')),
+      ).toBe(true);
+    });
+
     it('rejects nonexistent article', () => {
       expect(() =>
         repo.recordUsageEvent({

--- a/tests/pipeline/actions.test.ts
+++ b/tests/pipeline/actions.test.ts
@@ -203,6 +203,7 @@ describe('STAGE_ACTIONS', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     fixtures.memory.close();
     fixtures.repo.close();
     rmSync(fixtures.tempDir, { recursive: true, force: true });
@@ -915,6 +916,38 @@ describe('Token usage recording', () => {
     expect(events[0].model_or_tool).toMatch(/^gpt-5/);
     expect(events[0].prompt_tokens).toBe(432);
     expect(events[0].output_tokens).toBe(210);
+  });
+
+  it('keeps same-second usage history deterministic without timing sleeps', () => {
+    fixtures.repo.createArticle({ id: 'test-usage-order', title: 'Usage Order Test' });
+
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-03-22T00:00:00Z'));
+      for (const [surface, promptTokens] of [
+        ['generatePrompt', 100],
+        ['composePanel', 200],
+        ['runDiscussion', 300],
+      ] as const) {
+        recordAgentUsage(fixtures.ctx, 'test-usage-order', 1, surface, {
+          content: 'test',
+          thinking: null,
+          model: 'gpt-4o',
+          provider: 'openai',
+          agentName: 'writer',
+          memoriesUsed: 0,
+          tokensUsed: { prompt: promptTokens, completion: 25 },
+        });
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(fixtures.repo.getUsageEvents('test-usage-order').map((event) => event.surface)).toEqual([
+      'runDiscussion',
+      'composePanel',
+      'generatePrompt',
+    ]);
   });
 
   it('does not record usage when tokensUsed is undefined', () => {


### PR DESCRIPTION
## Summary
- add an article-history-friendly `usage_events` index for per-article history reads
- make `getUsageEvents()` deterministic for same-second rows while preserving explicit bounded reads
- replace timing-fragile usage-history tests with deterministic same-second regression coverage

Closes #104.

## Testing
- npm run v2:test -- tests/db/repository.test.ts tests/pipeline/actions.test.ts tests/dashboard/server.test.ts
- npm run v2:build