### PR TITLE
fix: unblock Stage 7 manual publish (#111)

### DIFF
--- a/.squad/agents/code/history.md
+++ b/.squad/agents/code/history.md
@@ -10,6 +10,7 @@
 
 ## Learnings
 
+- 2026-03-23 — PR #113 cleanup: Stage 7 manual publish readiness belongs to the dashboard action panel (`src/dashboard/views/article.ts`) and should key off `substack_draft_url`, with the regression anchored in `tests/dashboard/server.test.ts`.
 - Team initialized 2025-07-18
 - Issue #92 writer revisions should receive the full latest `editor-review.md` artifact in `articleContext` while keeping `conversationContext` limited to the compact revision handoff. That preserves anti-role-bleed for writer/editor/publisher without hiding exact editor instructions from the writer.
 - 47 article pipeline agents live in `src/config/defaults/charters/nfl/` — these are SEPARATE from Squad agents

--- a/.squad/decisions/inbox/code-pr113-conflict.md
+++ b/.squad/decisions/inbox/code-pr113-conflict.md
@@ -1,0 +1,7 @@
+# Decision: Rebase PR #113 to replay only the Stage 7 publish fix
+
+- **Issue:** #111 / PR #113
+- **Context:** PR #113 was opened from a branch still stacked on `ux/issue-93-copilot-usage`, so after PR #112 landed the PR still carried unrelated history and showed a dirty merge state against `main`.
+- **Decision:** Rebase `fix/issue-111-publish-ui` directly onto `origin/main` and keep only the Stage 7 manual publish action-panel change plus its focused regression.
+- **Why:** The actual bug is local to the article detail action panel: Stage 7 manual publish should be enabled when `substack_draft_url` exists, even though the pipeline advance guard still expects `substack_url` for Stage 7→8 advancement.
+- **Implementation paths:** `src/dashboard/views/article.ts`, `tests/dashboard/server.test.ts`.

--- a/src/dashboard/views/article.ts
+++ b/src/dashboard/views/article.ts
@@ -507,6 +507,10 @@ function renderActionPanel(article: Article, advanceCheck?: AdvanceCheck, stageR
 
   // Stage 7 — publish flow (no retry button, uses publish button instead)
   if (article.current_stage === 7) {
+    const hasDraft = !!article.substack_draft_url;
+    const publishStatus = hasDraft
+      ? 'Substack draft ready for manual publish'
+      : 'Create a Substack draft in the publish workspace before publishing';
     const canRegress = true; // Stage 7 can always go back
     const regressOptions = Array.from({ length: article.current_stage - 1 }, (_, i) => {
       const stage = (i + 1) as Stage;
@@ -525,6 +529,7 @@ function renderActionPanel(article: Article, advanceCheck?: AdvanceCheck, stageR
           ${article.substack_draft_url
             ? `<a href="${escapeHtml(article.substack_draft_url)}" target="_blank" class="btn btn-secondary">Draft ↗</a>`
             : ''}
+          <a href="/articles/${escapeHtml(article.id)}/publish" class="btn btn-secondary">Open Publish Workspace</a>
           ${previewLink}
           <button class="btn btn-publish"
             hx-post="/api/articles/${escapeHtml(article.id)}/publish"
@@ -532,7 +537,7 @@ function renderActionPanel(article: Article, advanceCheck?: AdvanceCheck, stageR
             hx-swap="innerHTML"
             hx-confirm="Publish this article to Substack?"
             hx-on::after-settle="if(event.detail.successful) { setTimeout(() => window.location.reload(), 2000); }"
-            ${canAdvance ? '' : 'disabled'}>
+            ${hasDraft ? '' : 'disabled title="Create a Substack draft first"'}>
             Publish to Substack
           </button>
           <details class="send-back-dropdown">
@@ -551,7 +556,7 @@ function renderActionPanel(article: Article, advanceCheck?: AdvanceCheck, stageR
             </form>
           </details>
         </div>
-        ${renderGuardStatus(canAdvance, guardReason)}
+        ${renderGuardStatus(hasDraft, publishStatus)}
         ${stageRunErrorHtml}
         <div id="advance-result-${escapeHtml(article.id)}"></div>
         ${renderDangerZone(article)}

--- a/tests/dashboard/server.test.ts
+++ b/tests/dashboard/server.test.ts
@@ -631,6 +631,24 @@ describe('Dashboard Server', () => {
       const article = repo.getArticle('adv-ok');
       expect(article!.current_stage).toBe(2);
     });
+
+    it('uses draft readiness for stage 7 publish actions instead of the stage guard failure', async () => {
+      repo.createArticle({ id: 'stage7-publish', title: 'Stage 7 Publish' });
+      for (let s = 2; s <= 7; s++) {
+        repo.advanceStage('stage7-publish', s - 1, s, 'test');
+      }
+      repo.setDraftUrl('stage7-publish', 'https://test.substack.com/publish/post/12345');
+
+      const res = await app.request('/articles/stage7-publish');
+      const html = await res.text();
+
+      expect(html).toContain('Open Publish Workspace');
+      expect(html).toContain('Publish to Substack');
+      expect(html).toContain('Substack draft ready for manual publish');
+      expect(html).not.toContain('substack_url not set on article');
+      expect(html).toContain('Draft ↗');
+      expect(html).not.toContain('disabled>Publish to Substack');
+    });
   });
 
   // ── Regress endpoints ───────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #111.

## Summary
- stop using the Stage 7 pipeline `substack_url` guard to disable manual publishing in the article detail action panel
- enable publish when a Substack draft exists and surface an `Open Publish Workspace` shortcut
- add a dashboard regression test covering Stage 7 draft-ready publish behavior

## Validation
- `npm run v2:build`
- `npx vitest run tests/dashboard/server.test.ts tests/dashboard/publish.test.ts`

## Notes
- `npm run v2:test` still reports an unrelated existing failure in `tests/dashboard/new-idea.test.ts` (`POST /api/ideas ... generates idea via LLM and extracts title` timing out)
